### PR TITLE
Update BestieTemplate.jl URL to JuliaBesties

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -9,4 +9,4 @@ PackageName: TriangleSingularity
 PackageOwner: mmikhasenko
 PackageUUID: 806edd40-9488-453b-b3e3-cb1e12902d3c
 _commit: v0.10.1
-_src_path: https://github.com/abelsiqueira/BestieTemplate.jl
+_src_path: https://github.com/JuliaBesties/BestieTemplate.jl


### PR DESCRIPTION
This is a semi-automated PR.
BestieTemplate.jl has been moved to the JuliaBesties organization.
This updates the URL in .copier-answers.yml to point to the new location.
